### PR TITLE
Patch to ensure web controller/core gets built from R2.1 

### DIFF
--- a/debian/contrail-web-controller/debian/rules
+++ b/debian/contrail-web-controller/debian/rules
@@ -8,7 +8,7 @@ override_dh_installinit:
 	dh_installinit --name=contrail-webui-jobserver
 	dh_installinit --name=contrail-webui-webserver
 	
-#BRANCH=--branch R1.06
+BRANCH=--branch R2.1
 #TAGS=tags/v1.06
 SRC_PACKAGE = contrail-web-controller
 SRC_VERSION := $(shell dpkg-parsechangelog | sed -ne 's/^Version: \(\([0-9]\+\):\)\?\(.*\)/\3/p')

--- a/debian/contrail-web-core/debian/rules
+++ b/debian/contrail-web-core/debian/rules
@@ -3,7 +3,7 @@
 %:
 	dh $@
 
-#BRANCH=--branch R1.06
+BRANCH=--branch R2.1
 #TAGS=tags/v1.06
 SRC_PACKAGE = contrail-web-core
 SRC_VERSION := $(shell dpkg-parsechangelog | sed -ne 's/^Version: \(\([0-9]\+\):\)\?\(.*\)/\3/p')


### PR DESCRIPTION
Patch to ensure web controller/core gets built from R2.1 master
This fixes the issue of missing js file during installtion of contrail web controller.