### PR TITLE
Fix nodejs version

### DIFF
--- a/debian/contrail-web-core/debian/control
+++ b/debian/contrail-web-core/debian/control
@@ -10,7 +10,7 @@ Homepage: https://github.com/Juniper/contrail-web-core/
 
 Package: contrail-web-core
 Architecture: amd64
-Depends: nodejs (= 0.8.15-1contrail1), redis-server, ${misc:Depends}
+Depends: nodejs (>= 0.8.15-1contrail1), redis-server, ${misc:Depends}
 Description: OpenContrail WebUI Core
  OpenContrail Web UI for the management of Contrail network virtualization
  solution. This module interacts with other components of both Contrail network


### PR DESCRIPTION
Currently nodejs is hard set to v0.8.15 , whereas we are packaging nodejs v0.10 hence this creates conflicts during installation. Changing the control file of contrail-web-core to include  >=v0.8.15